### PR TITLE
Add missing requirement to setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -58,6 +58,7 @@ install_requires =
     lxml
     trimesh>=3.9.32
     numpy
+    six
 
 
 [options.packages.find]


### PR DESCRIPTION
This missing requirement prevented tox from functioning properly and otherwise breaks installs