### PR TITLE
Draft: Apply visual colors when available

### DIFF
--- a/src/yourdfpy/urdf.py
+++ b/src/yourdfpy/urdf.py
@@ -239,12 +239,9 @@ def apply_visual_color(geom: trimesh.Trimesh, visual: Visual):
     if visual.material is None or visual.material.color is None:
         return
     n = len(geom.visual.face_colors)
-    int_color = [int(255 * channel) for  channel in visual.material.color.rgba]
-    for i in range(n):
-        geom.visual.face_colors[i][0] = int_color[0]
-        geom.visual.face_colors[i][1] = int_color[1]
-        geom.visual.face_colors[i][2] = int_color[2]
-        geom.visual.face_colors[i][3] = int_color[3]
+    geom.visual.face_colors[:] = [
+        int(255 * channel) for  channel in visual.material.color.rgba
+    ]
 
 
 def filename_handler_null(fname):

--- a/src/yourdfpy/urdf.py
+++ b/src/yourdfpy/urdf.py
@@ -238,7 +238,6 @@ def _str2float(s):
 def apply_visual_color(geom: trimesh.Trimesh, visual: Visual):
     if visual.material is None or visual.material.color is None:
         return
-    n = len(geom.visual.face_colors)
     geom.visual.face_colors[:] = [
         int(255 * channel) for  channel in visual.material.color.rgba
     ]

--- a/src/yourdfpy/urdf.py
+++ b/src/yourdfpy/urdf.py
@@ -235,6 +235,18 @@ def _str2float(s):
     return float(s) if s is not None else None
 
 
+def apply_visual_color(geom: trimesh.Trimesh, visual: Visual):
+    if visual.material is None or visual.material.color is None:
+        return
+    n = len(geom.visual.face_colors)
+    int_color = [int(255 * channel) for  channel in visual.material.color.rgba]
+    for i in range(n):
+        geom.visual.face_colors[i][0] = int_color[0]
+        geom.visual.face_colors[i][1] = int_color[1]
+        geom.visual.face_colors[i][2] = int_color[2]
+        geom.visual.face_colors[i][3] = int_color[3]
+
+
 def filename_handler_null(fname):
     """A lazy filename handler that simply returns its input.
 
@@ -1069,6 +1081,8 @@ class URDF:
 
                     if force_single_geometry:
                         for name, geom in new_s.geometry.items():
+                            if isinstance(v, Visual):
+                                apply_visual_color(geom, v)
                             tmp_scene.add_geometry(
                                 geometry=geom,
                                 geom_name=v.name,
@@ -1077,6 +1091,8 @@ class URDF:
                             )
                     else:
                         for name, geom in new_s.geometry.items():
+                            if isinstance(v, Visual):
+                                apply_visual_color(geom, v)
                             s.add_geometry(
                                 geometry=geom,
                                 geom_name=v.name,


### PR DESCRIPTION
If I understand correctly, visual materials are currently read and written but not rendered. Loading e.g. the [Upkie](https://github.com/tasts-robots/upkie_description) URDF we get the dark "ninja" version:

![upkie-ninja](https://user-images.githubusercontent.com/1189580/161933384-6c3c4731-8f60-46b8-aaac-389817d6cbb1.png)

Trimesh can render materials so getting them to yourdfpy is a matter of plugging the right info. This PR starts to do so:

![upkie-colored-chassis](https://user-images.githubusercontent.com/1189580/161933563-0bc41275-c283-4653-bf53-dd96d6f21076.png)

For now it only works for materials that contain an actual color tag (i.e. no named materials).