### PR TITLE
Cast down NumPy array to float

### DIFF
--- a/src/yourdfpy/urdf.py
+++ b/src/yourdfpy/urdf.py
@@ -1069,7 +1069,7 @@ class URDF:
             if joint.type == "prismatic":
                 matrix = origin @ tra.translation_matrix(q * joint.axis)
             else:
-                matrix = origin @ tra.rotation_matrix(q, joint.axis)
+                matrix = origin @ tra.rotation_matrix(float(q), joint.axis)
         else:
             # this includes: floating, planar, fixed
             matrix = origin


### PR DESCRIPTION
Fixes https://github.com/clemense/yourdfpy/issues/49

After upgrading NumPy and SciPy to respectively 1.24.4 and 1.10.1 I started to get the following error when trying to load a robot URDF:

    Traceback (most recent call last):
      File "load_in_yourdfpy.py", line 36, in <module>
        robot = load_robot_description(f"{args.name}_description")
      File "/home/user/src/robot_descriptions.py/examples/robot_descriptions/loaders/yourdfpy.py", line 58, in load_robot_description
        return yourdfpy.URDF.load(module.URDF_PATH, mesh_dir=module.PACKAGE_PATH)
      File "/home/user/.local/lib/python3.8/site-packages/yourdfpy/urdf.py", line 989, in load
        return URDF(robot=URDF._parse_robot(xml_element=xml_root), **kwargs)
      File "/home/user/.local/lib/python3.8/site-packages/yourdfpy/urdf.py", line 641, in __init__
        self._scene = self._create_scene(
      File "/home/user/.local/lib/python3.8/site-packages/yourdfpy/urdf.py", line 1321, in _create_scene
        matrix, _ = self._forward_kinematics_joint(j)
      File "/home/user/.local/lib/python3.8/site-packages/yourdfpy/urdf.py", line 1072, in _forward_kinematics_joint
        matrix = origin @ tra.rotation_matrix(q, joint.axis)
      File "/home/user/.local/lib/python3.8/site-packages/trimesh/transformations.py", line 361, in rotation_matrix
        M = np.diag([cosa, cosa, cosa, 1.0])
      File "<__array_function__ internals>", line 200, in diag
      File "/home/user/.local/lib/python3.8/site-packages/numpy/lib/twodim_base.py", line 295, in diag
        v = asanyarray(v)
    ValueError: setting an array element with a sequence. The requested array has an inhomogeneous shape after 1 dimensions. The detected shape was (4,) + inhomogeneous part.

The issue stems from urdf.py where:

    matrix = origin @ tra.rotation_matrix(q, joint.axis)

Won't work well by asanyarray (as per the new requirements) if q is a one-dimensional array, which can happen here. I'll suggest a fix in a PR.