### PR TITLE
fix _forward_kinematics_joint() when configuration passed to update_cfg() is just a dictionary of str-float pairs

### DIFF
--- a/src/yourdfpy/urdf.py
+++ b/src/yourdfpy/urdf.py
@@ -1073,7 +1073,11 @@ class URDF:
             if joint.type == "prismatic":
                 matrix = origin @ tra.translation_matrix(q * joint.axis)
             else:
-                matrix = origin @ tra.rotation_matrix(float(q.item()), joint.axis)
+                if isinstance(q, float):
+                    matrix = origin @ tra.rotation_matrix(q, joint.axis)
+                else:
+                    matrix = origin @ tra.rotation_matrix(float(q.item()), joint.axis)
+                
         else:
             # this includes: floating, planar, fixed
             matrix = origin


### PR DESCRIPTION
commit 9aabbff5751c8a56ac2a2249dbfdc365cc98472c breaks update_cfg() call when `configuration` is just a dictionary of str-float pairs.
This commit adds a check to ensure correct behavior when target joint positions are just floats.