### PR TITLE
Make Collision.name optional and fix texture.filename XML write failure

### DIFF
--- a/src/yourdfpy/urdf.py
+++ b/src/yourdfpy/urdf.py
@@ -209,7 +209,7 @@ class Visual:
 
 @dataclass(eq=False)
 class Collision:
-    name: str
+    name: Optional[str] = None
     origin: Optional[np.ndarray] = None
     geometry: Geometry = None
 
@@ -1800,7 +1800,12 @@ class URDF:
             return
 
         # TODO: use texture filename handler
-        etree.SubElement(xml_parent, "texture", attrib={"filename": texture.filename})
+        attrib = {"filename": texture.filename} if texture.filename is not None else {}
+        etree.SubElement(
+            xml_parent,
+            "texture",
+            attrib=attrib,
+        )
 
     def _parse_material(xml_element):
         if xml_element is None:


### PR DESCRIPTION
This Pull Request addresses https://github.com/clemense/yourdfpy/issues/66 and also makes Collision.name an optional attribute, as in the URDF specification (https://wiki.ros.org/urdf/XML/link#Attributes). I tried to format the changed code in the way the rest of the code is formatted.